### PR TITLE
Pyttsx3 edits

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
     - sf2utils
     - sphinx
     - tqdm
+    - "--editable=git+https://github.com/nateshmbhat/pyttsx3.git"
     - pyttsx3
     - wavio
     - wheel

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
     - sf2utils
     - sphinx
     - tqdm
-    - TTS
+    - pyttsx3
     - wavio
     - wheel
     - sounddevice

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
     - sf2utils
     - sphinx
     - tqdm
-    - "--editable=git+https://github.com/nateshmbhat/pyttsx3.git"
+    - "--editable=git+https://github.com/nateshmbhat/pyttsx3.git#egg=pyttsx3"
     - pyttsx3
     - wavio
     - wheel

--- a/examples/AudioCaption.ipynb
+++ b/examples/AudioCaption.ipynb
@@ -153,7 +153,8 @@
     "                       ttsmodel=str(Path('tts_models', 'en', 'ljspeech', 'tacotron2-DDC')))\n",
     "elif mode == 'pyttsx3':\n",
     "    for v in voices[::-1]:\n",
-    "        if v.languages[0].split('_')[0] == 'en':\n",
+    "        #print(v.languages[0][:2])\n",
+    "        if v.languages[0][:2] == 'en':\n",
     "            break\n",
     "    print(f\"Selected voice: {v.name}\")\n",
     "    soni = Sonification(score, events, generator, system,\n",
@@ -190,7 +191,7 @@
     "elif mode == 'pyttsx3':\n",
     "    # find a German-language voice...\n",
     "    for v in voices:\n",
-    "        if v.languages[0].split('_')[0] == 'de':\n",
+    "        if v.languages[0][:2] == 'de':\n",
     "            break\n",
     "    soni = Sonification(score, events, generator, system,\n",
     "                        caption=caption_de,\n",
@@ -217,11 +218,25 @@
    "source": [
     "symbol_examples_en = 'The Lyman-α resonance is 1216 Å. The Lyman alpha resonance is twelve hundred and sixteen angstroms. '\n",
     "\n",
+    "for v in voices[::-1]:\n",
+    "        #print(v.languages[0][:2])\n",
+    "        if v.languages[0][:2] == 'en':\n",
+    "            break\n",
+    "                       \n",
     "soni = Sonification(score, events, generator, system,\n",
-    "                    caption=symbol_examples_en)\n",
+    "                    caption=symbol_examples_en, ttsmodel={'voice':v.id, 'rate': 217})\n",
+    "\n",
     "soni.render()\n",
     "soni.notebook_display(show_waveform=0)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f706e822-d989-4b2a-b834-b1565548349d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -240,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.8.20"
   }
  },
  "nbformat": 4,

--- a/examples/AudioCaption.ipynb
+++ b/examples/AudioCaption.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "### <u> Generate a sonification with an audio caption in `strauss` </u>\n",
-    "Import the relevant modules:"
+    "Import the relevant modules:\n",
+    "\n",
+    "***Note***: you will need to have some form of python text-to-speech installed (`TTS` or `pyttsx3`) for these examples to work. See the error raised when trying to run the examples below for more info:"
    ]
   },
   {
@@ -27,7 +29,28 @@
     "from strauss.generator import Sampler\n",
     "import os\n",
     "from pathlib import Path\n",
-    "%matplotlib inline"
+    "import strauss\n",
+    "%matplotlib inline\n",
+    "\n",
+    "mode = strauss.tts_caption.ttsMode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "226f3af8-eea8-4f8e-b537-bda602e1418d",
+   "metadata": {},
+   "source": [
+    "What text to speech do we have?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffe715e8-d5aa-487d-a125-0e17a6a01958",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Available text-to-speech (TTS) is: {mode}\")"
    ]
   },
   {
@@ -46,7 +69,6 @@
    "outputs": [],
    "source": [
     "# platform agnostic absolute path for samples...\n",
-    "import strauss\n",
     "strauss_dir = Path(strauss.__file__).parents[2]\n",
     "sample_path = Path(strauss_dir, 'data','samples','glockenspiels')\n",
     "# setup used in stars appearing example\n",
@@ -76,10 +98,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ce448cfd-bd92-49d1-9c1d-c3c4d6252383",
+   "metadata": {},
+   "source": [
+    "Now, lets look at the avaialble voices for our TTS engine:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e50a986e-5c51-4d1a-aea5-99f3161cdd9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from strauss.tts_caption import TTS\n",
+    "voices = TTS().list_models()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b7d1566f-ff8c-4e21-8ceb-f743394fa4a5",
    "metadata": {},
    "source": [
-    "Generate text-to-speech (TTS) for the caption, using the default choice of voice (`\"Jenny\"` from the `TTS` module)"
+    "Generate text-to-speech (TTS) for the caption, using the default choice of voice (`\"Jenny\"` for the `coqui-tts` module, OS default for `pyttsx3`)"
    ]
   },
   {
@@ -91,7 +132,6 @@
    "source": [
     "caption_en = 'In the following audio, a glockenspiel is used to represent stars of varying colour.'\n",
     "\n",
-    "# render at default 48 kHz rate\n",
     "soni = Sonification(score, events, generator, system,\n",
     "                    caption=caption_en)\n",
     "soni.render()\n",
@@ -107,9 +147,21 @@
    "source": [
     "caption_en = 'In the following audio, a glockenspiel is used to represent stars of varying colour.'\n",
     "\n",
-    "soni = Sonification(score, events, generator, system,\n",
-    "                    caption=caption_en,\n",
-    "                   ttsmodel=str(Path('tts_models', 'en', 'ljspeech', 'tacotron2-DDC')))\n",
+    "if mode == 'coqui-tts':\n",
+    "    soni = Sonification(score, events, generator, system,\n",
+    "                        caption=caption_en,\n",
+    "                       ttsmodel=str(Path('tts_models', 'en', 'ljspeech', 'tacotron2-DDC')))\n",
+    "elif mode == 'pyttsx3':\n",
+    "    for v in voices[::-1]:\n",
+    "        if v.languages[0].split('_')[0] == 'en':\n",
+    "            break\n",
+    "    print(f\"Selected voice: {v.name}\")\n",
+    "    soni = Sonification(score, events, generator, system,\n",
+    "                        caption=caption_en,\n",
+    "                       ttsmodel={'voice':v.id,\n",
+    "                                 # we can also set a rate for pyttsx3 (int16)...\n",
+    "                                'rate': 217})\n",
+    "\n",
     "soni.render()\n",
     "soni.notebook_display(show_waveform=False)"
    ]
@@ -131,9 +183,19 @@
    "source": [
     "caption_de = \"In der folgenden Tonspur wird ein Glockenspiel verwendet um Sterne mit unterschiedlichen Farben zu repräsentieren.\"\n",
     "\n",
-    "soni = Sonification(score, events, generator, system,\n",
-    "                    caption=caption_de, \n",
-    "                    ttsmodel=str(Path('tts_models', 'de', 'thorsten', 'vits')))\n",
+    "if mode == 'coqui-tts':\n",
+    "    soni = Sonification(score, events, generator, system,\n",
+    "                        caption=caption_de, \n",
+    "                        ttsmodel=str(Path('tts_models', 'de', 'thorsten', 'vits')))\n",
+    "elif mode == 'pyttsx3':\n",
+    "    # find a German-language voice...\n",
+    "    for v in voices:\n",
+    "        if v.languages[0].split('_')[0] == 'de':\n",
+    "            break\n",
+    "    soni = Sonification(score, events, generator, system,\n",
+    "                        caption=caption_de,\n",
+    "                        ttsmodel={'voice':v.id})\n",
+    "\n",
     "soni.render()\n",
     "soni.notebook_display(show_waveform=False)"
    ]
@@ -143,7 +205,7 @@
    "id": "ff8db018-02e3-48c2-a043-6ba132c1e239",
    "metadata": {},
    "source": [
-    "**Note**: the AI-based `TTS` can behave strangely when using unrecognised characters or terms. Sometimes these will be mispronounced by the TTS, other times they could be skipped entirely. This can be circumvented by writing out the how symbols should be pronounced, or spelling phonetically to improve pronunciation:"
+    "**Note**: the AI-based `TTS` can behave unpredictably when using unrecognised characters or terms. Sometimes these will be mispronounced by the TTS, other times they could be skipped entirely. This can be circumvented by writing out the how symbols should be pronounced, or spelling phonetically to improve pronunciation:"
    ]
   },
   {
@@ -156,30 +218,9 @@
     "symbol_examples_en = 'The Lyman-α resonance is 1216 Å. The Lyman alpha resonance is twelve hundred and sixteen angstroms. '\n",
     "\n",
     "soni = Sonification(score, events, generator, system,\n",
-    "                    caption=symbol_examples_en+caption_en)\n",
+    "                    caption=symbol_examples_en)\n",
     "soni.render()\n",
     "soni.notebook_display(show_waveform=0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5a9db75d-6da4-4a9c-92d6-e31caee18e86",
-   "metadata": {},
-   "source": [
-    "Captions can be used to provide context to sonifications, explaining what to listen for.\n",
-    "\n",
-    "We can list available models for the TTS module (including `Jenny` the default `strauss` voice):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c216a84c-2fd4-46a0-abc1-a152bc77b639",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from strauss.tts_caption import TTS\n",
-    "TTS().list_models()"
    ]
   }
  ],

--- a/examples/AudioCaption.py
+++ b/examples/AudioCaption.py
@@ -3,6 +3,9 @@
 
 # ### <u> Generate a sonification with an audio caption in `strauss` </u>
 # Import the relevant modules:
+# 
+# ***Note***: you will need to have some form of python text-to-speech installed (`TTS` or `pyttsx3`) for these examples to work. See the error raised when trying to run the examples below for more info:
+
 
 from strauss.sonification import Sonification
 from strauss.sources import Events
@@ -12,13 +15,20 @@ from strauss.tts_caption import render_caption
 import numpy as np
 from strauss.generator import Sampler
 import os
-import pprint
 from pathlib import Path
+import strauss
+
+mode = strauss.tts_caption.ttsMode
+
+
+# What text to speech do we have?
+print(f"Available text-to-speech (TTS) is: {mode}")
+
 
 # Generate a placeholder sonification (a short sequence of glockenspiel notes) that we may want to add a caption to:
 
+
 # platform agnostic absolute path for samples...
-import strauss
 strauss_dir = Path(strauss.__file__).parents[2]
 sample_path = Path(strauss_dir, 'data','samples','glockenspiels')
 
@@ -47,26 +57,36 @@ events.fromdict(data)
 events.apply_mapping_functions(map_lims=maplims)
 
 
-# Generate text-to-speech (TTS) for the caption, using the default choice of voice (`"Jenny"` from the `TTS` module)
+# Now, lets look at the avaialble voices for our TTS engine:
+from strauss.tts_caption import TTS
+voices = TTS().list_models()
 
+
+# Generate text-to-speech (TTS) for the caption, using the default choice of voice (`"Jenny"` for the `coqui-tts` module, OS default for `pyttsx3`)
 caption_en = 'In the following audio, a glockenspiel is used to represent stars of varying colour.'
 
-print("Example of a caption using the default voice...")
-
-# render at default 48 kHz rate
 soni = Sonification(score, events, generator, system,
                     caption=caption_en)
 soni.render()
 soni.hear()
 
-
 caption_en = 'In the following audio, a glockenspiel is used to represent stars of varying colour.'
 
-print("Example of a caption using an alternative voice...")
+if mode == 'coqui-tts':
+    soni = Sonification(score, events, generator, system,
+                        caption=caption_en,
+                       ttsmodel=str(Path('tts_models', 'en', 'ljspeech', 'tacotron2-DDC')))
+elif mode == 'pyttsx3':
+    for v in voices[::-1]:
+        if v.languages[0][:2] == 'en':
+            break
+    print(f"Selected voice: {v.name}")
+    soni = Sonification(score, events, generator, system,
+                        caption=caption_en,
+                       ttsmodel={'voice':v.id,
+                                 # we can also set a rate for pyttsx3 (int16)...
+                                'rate': 217})
 
-soni = Sonification(score, events, generator, system,
-                    caption=caption_en,
-                   ttsmodel=Path('tts_models', 'en', 'ljspeech', 'tacotron2-DDC'))
 soni.render()
 soni.hear()
 
@@ -75,31 +95,34 @@ soni.hear()
 
 caption_de = "In der folgenden Tonspur wird ein Glockenspiel verwendet um Sterne mit unterschiedlichen Farben zu repräsentieren."
 
-print("Example of a caption in a different language (German), selecting a voice supportingh that language ('Thorsten')...")
+if mode == 'coqui-tts':
+    soni = Sonification(score, events, generator, system,
+                        caption=caption_de, 
+                        ttsmodel=str(Path('tts_models', 'de', 'thorsten', 'vits')))
+elif mode == 'pyttsx3':
+    # find a German-language voice...
+    for v in voices:
+        if v.languages[0][:2] == 'de':
+            break
+    soni = Sonification(score, events, generator, system,
+                        caption=caption_de,
+                        ttsmodel={'voice':v.id})
 
-soni = Sonification(score, events, generator, system,
-                    caption=caption_de, 
-                    ttsmodel=Path('tts_models', 'de', 'thorsten', 'vits'))
 soni.render()
 soni.hear()
 
 
-# **Note**: the AI-based `TTS` can behave strangely when using unrecognised characters or terms. Sometimes these will be mispronounced by the TTS, other times they could be skipped entirely. This can be circumvented by writing out the how symbols should be pronounced, or spelling phonetically to improve pronunciation:
+# **Note**: the AI-based `TTS` can behave unpredictably when using unrecognised characters or terms. Sometimes these will be mispronounced by the TTS, other times they could be skipped entirely. This can be circumvented by writing out the how symbols should be pronounced, or spelling phonetically to improve pronunciation:
 
 symbol_examples_en = 'The Lyman-α resonance is 1216 Å. The Lyman alpha resonance is twelve hundred and sixteen angstroms. '
 
-print("Example of mispronunciation of terms or symbols...")
-
+for v in voices[::-1]:
+        if v.languages[0][:2] == 'en':
+            break
+                       
 soni = Sonification(score, events, generator, system,
-                    caption=symbol_examples_en+caption_en)
+                    caption=symbol_examples_en, ttsmodel={'voice':v.id, 'rate': 217})
+
 soni.render()
 soni.hear()
 
-
-# Captions can be used to provide context to sonifications, explaining what to listen for.
-# 
-# We can list available models for the TTS module (including `Jenny` the default `strauss` voice):
-
-print("Print available voice models...")
-from strauss.tts_caption import TTS
-pprint.pprint(TTS().list_models().list_tts_models())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires = [
     "sf2utils",
     "tqdm",
     "wavio",
-    "wheel"
+    "wheel",
+    "pyttsx3 @ git+https://github.com/nateshmbhat/pyttsx3.git"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,4 @@ where = src
 [options.extras_require]
 TTS =
  TTS
+ pyttsx3

--- a/src/strauss/tts_caption.py
+++ b/src/strauss/tts_caption.py
@@ -6,10 +6,15 @@ import re
 import ffmpeg as ff
 import os
 import warnings
+class NoTTSAPI(Exception):
+    # except when no API key is found for coqui-TTS module
+    pass
 try:
     from TTS.api import TTS
     ttsMode = 'coqui-TTS'
-except (OSError, ModuleNotFoundError) as sderr:
+    if not os.environ.get("COQUI_STUDIO_TOKEN"):
+        raise NoTTSAPI
+except (OSError, ModuleNotFoundError, NoTTSAPI) as sderr:
     try:
       import pyttsx3
       ttsMode = 'pyttsx3'
@@ -29,7 +34,7 @@ except (OSError, ModuleNotFoundError) as sderr:
                 "Reinstalling strauss with 'pip install strauss[TTS]' will give you access to this function\n"
                 "If you run into issues with the TTS package, you can also install pyttsx3 with the command\n" 
                 "'pip install pyttsx3'.")
-    
+
 class TTSIsNotSupported(Exception):
     pass
 

--- a/src/strauss/tts_caption.py
+++ b/src/strauss/tts_caption.py
@@ -32,8 +32,9 @@ except (OSError, ModuleNotFoundError, NoTTSAPI) as sderr:
           raise TTSIsNotSupported("strauss has not been installed with text-to-speech support. \n"
                 "This is not installed by default, due to some specific module requirements of the TTS module.\n"
                 "Reinstalling strauss with 'pip install strauss[TTS]' will give you access to this function\n"
-                "If you run into issues with the TTS package, you can also install pyttsx3 with the command\n" 
-                "'pip install pyttsx3'.")
+                "If you run into issues with the TTS package, you can also install pyttsx3. Currently the most\n" 
+                "compatible version is npt published on PyPI, but you can install from the git repo with \n"
+                "'pip install git+https://github.com/nateshmbhat/pyttsx3.git'.")
 
 class TTSIsNotSupported(Exception):
     pass

--- a/src/strauss/tts_caption.py
+++ b/src/strauss/tts_caption.py
@@ -5,12 +5,11 @@ import strauss.utilities as utils
 import re
 import ffmpeg as ff
 import os
-
+import warnings
 try:
     from TTS.api import TTS
     ttsMode = 'coqui-TTS'
 except (OSError, ModuleNotFoundError) as sderr:
-    # print('Coqui TTS not found. Trying to import pyttsx3...')
     try:
       import pyttsx3
       ttsMode = 'pyttsx3'
@@ -18,8 +17,9 @@ except (OSError, ModuleNotFoundError) as sderr:
           def __init__(*args, **kwargs):
               pass
           def list_models(self):
-              getVoices(True)
-      # print('pyttsx3 has been successfully imported.')
+              return getVoices(True)
+      warnings.warn("Default TTS module coqui not found, using pyttsx3 instead. Note this is platform \n"
+                    "dependent and still problematic for linux-based systems (using the espeak engine)")
     except (OSError, ModuleNotFoundError) as sderr:
       ttsMode = 'None'
       # print('No supported text-to-speech packages have been found.')
@@ -84,8 +84,9 @@ def render_caption(caption, samprate, model, caption_path):
       samprate (:obj:`int`): samples per second
       model (:obj:`str` for Coqui-AI; :obj:`dict` for pyttsx3): for Coqui-AI: 
         valid name of TTS voice from the underlying TTS module; for pyttsx3:
-        dictionary with keys of 'rate' (percent of speed), 'volume' (float from 0 to 1), 
-        and/or 'voices' ()
+        dictionary with keys of 'rate' (percent of speed, signed int16),
+        'volume' (float from 0 to 1), and/or 'voice' (the voice 'id' that can
+        be chosen from the list given by the TTS.list_models() function).
       caption_path (:obj:`str`): filepath for spoken caption output
     '''
 
@@ -108,23 +109,16 @@ def render_caption(caption, samprate, model, caption_path):
 
       # check what model info was set; if none were
       # specified, use defaults
-      for key in ['rate','volume','voices']:
+      for key in ['rate','volume','voice']:
           if key in model.keys():
               engine.setProperty(key, model[key])
           else:
               pass
 
-      engine.save_to_file(caption, caption_path)
-
-      try:
-          # TODO: explore why NSS triggers error hear without catching
-          engine.runAndWait()
-      except Exception as e:
-          print(e)
-          if engine._inLoop:
-              engine.endLoop()
-          pass
-
+      engine.save_to_file(caption, caption_path, name='caption')
+      # note the current PyPI release ()
+      engine.runAndWait()
+      
     else:
        # initialise dummy TTS class to raise error.
        TTS()
@@ -140,7 +134,6 @@ def render_caption(caption, samprate, model, caption_path):
         os.rename(caption_path, cpre)
         ff.input(cpre).output(caption_path).run(quiet=1)
         rate_in, wavobj = wavfile.read(caption_path)
-
         
     # If it doesn't match the required rate, resample and re-write
     if rate_in != samprate:

--- a/src/strauss/tts_caption.py
+++ b/src/strauss/tts_caption.py
@@ -3,19 +3,26 @@ from scipy.interpolate import interp1d
 import numpy as np
 import strauss.utilities as utils
 import re
+import ffmpeg as ff
+import os
 
 try:
     from TTS.api import TTS
     ttsMode = 'coqui-TTS'
 except (OSError, ModuleNotFoundError) as sderr:
-    print('Coqui TTS not found. Trying to import pyttsx3...')
+    # print('Coqui TTS not found. Trying to import pyttsx3...')
     try:
       import pyttsx3
       ttsMode = 'pyttsx3'
-      print('pyttsx3 has been successfully imported.')
+      class TTS:
+          def __init__(*args, **kwargs):
+              pass
+          def list_models(self):
+              getVoices(True)
+      # print('pyttsx3 has been successfully imported.')
     except (OSError, ModuleNotFoundError) as sderr:
       ttsMode = 'None'
-      print('No supported text-to-speech packages have been found.')
+      # print('No supported text-to-speech packages have been found.')
       def TTS(*args, **kwargs):
           raise TTSIsNotSupported("strauss has not been installed with text-to-speech support. \n"
                 "This is not installed by default, due to some specific module requirements of the TTS module.\n"
@@ -95,33 +102,49 @@ def render_caption(caption, samprate, model, caption_path):
           tts.tts_to_file(text=caption, file_path=caption_path)
     
     elif ttsMode == 'pyttsx3':
-      print('Rendering caption (this can take a while if the caption is long)...')
-      
-      # capture stdout from the talkative TTS module
-      with utils.Capturing() as output:
-          # Setup voice model for pyttsx3
-          engine = pyttsx3.init() # initialize object
 
-          # check what model info was set; if none were
-          # specified, use defaults
-          for key in ['rate','volume','voices']:
-              if key in model.keys():
-                engine.setProperty(key, model[key])
+      # Setup voice model for pyttsx3
+      engine = pyttsx3.init() # initialize object
+
+      # check what model info was set; if none were
+      # specified, use defaults
+      for key in ['rate','volume','voices']:
+          if key in model.keys():
+              engine.setProperty(key, model[key])
           else:
-             pass
+              pass
 
-          # render to speech, and write as a wav file (allow )
-          engine.save_to_file(text=caption, filename=caption_path)
+      engine.save_to_file(caption, caption_path)
+
+      try:
+          # TODO: explore why NSS triggers error hear without catching
           engine.runAndWait()
+      except Exception as e:
+          print(e)
+          if engine._inLoop:
+              engine.endLoop()
+          pass
+
+    else:
+       # initialise dummy TTS class to raise error.
+       TTS()
           
     # Read the file back in to check the sample rate
-    rate_in, wavobj = wavfile.read(caption_path)
-    
-    #If it doesn't match the required rate, resample and re-write
+    try:
+        # Try to read in directly...
+        rate_in, wavobj = wavfile.read(caption_path)
+    except:
+        # ...but pttsx3 TTS can produce audio files incompatable
+        # with scipy - convert to standard WAV using ffmpeg
+        cpre = caption_path.split('.')[0] + '_pre.wav'
+        os.rename(caption_path, cpre)
+        ff.input(cpre).output(caption_path).run(quiet=1)
+        rate_in, wavobj = wavfile.read(caption_path)
+
+        
+    # If it doesn't match the required rate, resample and re-write
     if rate_in != samprate:
         new_wavobj = utils.resample(rate_in, samprate, wavobj)
         wavfile.write(caption_path, samprate, new_wavobj)
-    else:
-       TTS()
 
 


### PR DESCRIPTION
Thanks very much , Went into a bit of a rabbit hole trying to get this working on my Mac running Sonoma 14.2. `pyttsx3` appears to be quite platform dependent, so it would be good to test the implementation on other platforms (Windows, Linux).

For my system with these changes, the TTS work on a first-time run, but leave the tts engine in an abortive state. this is because I hit the error: `AttributeError: 'NSSpeechDriver' object has no attribute '_current_text'` (full stack below). This is why I need to put `engine.runAndWait()` in a try/except block.  To me this seems like a potential `pyttsx3` problem so I will raise an Issue.

@soleyhyman - what platform are you running on?

```
AttributeError                            Traceback (most recent call last)
Cell In[4], line 6
      3 # render at default 48 kHz rate
      4 soni = Sonification(score, events, generator, system,
      5                     caption=caption_en)
----> 6 soni.render()
      7 soni.notebook_display(show_waveform=0)

File ~/Documents/Code/strauss_dev/src/strauss/sonification.py:205, in Sonification.render(self, downsamp)
    203     else:
    204         pass
--> 205     render_caption(self.caption, self.samprate,
    206                self.ttsmodel, str(cpath))
    207 rate_in, wavobj = wavfile.read(cpath)
    208 wavobj = np.array(wavobj)

File ~/Documents/Code/strauss_dev/src/strauss/tts_caption.py:121, in render_caption(caption, samprate, model, caption_path)
    117 engine.save_to_file(caption, caption_path)
    119 try:
    120     # TODO: explore why NSS triggers error hear without catching
--> 121     engine.runAndWait()

File ~/Documents/Code/strauss_dev/venv/lib/python3.11/site-packages/pyttsx3/engine.py:183, in Engine.runAndWait(self)
    181 self._inLoop = True
    182 self._driverLoop = True
--> 183 self.proxy.runAndWait()

File ~/Documents/Code/strauss_dev/venv/lib/python3.11/site-packages/pyttsx3/driver.py:195, in DriverProxy.runAndWait(self)
    190 '''
    191 Called by the engine to start an event loop, process all commands in
    192 the queue at the start of the loop, and then exit the loop.
    193 '''
    194 self._push(self._engine.endLoop, tuple())
--> 195 self._driver.startLoop()

File ~/Documents/Code/strauss_dev/venv/lib/python3.11/site-packages/pyttsx3/drivers/nsss.py:77, in NSSpeechDriver.startLoop(self)
     75 if nextfire is not None:
     76     nextfire = soon.earlierDate_(nextfire)
---> 77 if not runLoop.runMode_beforeDate_(NSDefaultRunLoopMode, nextfire):
     78     stopper.stop()
     79     break

File ~/Documents/Code/strauss_dev/venv/lib/python3.11/site-packages/pyttsx3/drivers/nsss.py:159, in NSSpeechDriver.speechSynthesizer_willSpeakWord_ofString_(self, tts, rng, text)
    158 def speechSynthesizer_willSpeakWord_ofString_(self, tts, rng, text):
--> 159     if self._current_text:
    160         current_word = self._current_text[rng.location:rng.location + rng.length]
    161     else:

AttributeError: 'NSSpeechDriver' object has no attribute '_current_text'
```
